### PR TITLE
Wrongfully static variables.

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -6,8 +6,8 @@
 #include "map.h"
 #include "input.h"
 
-static int isGravitationEnabled = 0, isOnTheGround = 0;
-static float velocity = 0.0f;
+int isGravitationEnabled = 0, isOnTheGround = 0;
+float velocity = 0.0f;
 
 #include "input/kbmouse.c"
 #include "input/gamepad.c"


### PR DESCRIPTION
Variables `isGravitationEnabled`, `isOnTheGround`, and `velocity` shouldn't be declared as `static`, as they are accessed from other source files.